### PR TITLE
feat: upgrade to react 16.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "jsdoc": "^3.5.5",
     "microbundle": "^0.7.0",
     "prettier": "1.14.3",
-    "react": "^16.7.0-alpha.0",
-    "react-dom": "^16.7.0-alpha.0",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "react-scripts": "2.1.0",
     "rollup": "^0.67.1",
     "rollup-plugin-babel": "^4.0.3",
@@ -37,8 +37,8 @@
     "rollup-plugin-uglify": "^6.0.0"
   },
   "peerDependencies": {
-    "react": "^16.7.0-alpha.0",
-    "react-dom": "^16.7.0-alpha.0"
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Hooks are no longer alpha and were released in version 16.8